### PR TITLE
Scrollable sidebar and dashboard

### DIFF
--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -1,0 +1,4 @@
+
+.App {
+    overflow: hidden;
+}

--- a/src/styles/dashboard.scss
+++ b/src/styles/dashboard.scss
@@ -5,8 +5,8 @@
 }
 
 .dashboard {
-  padding: 16px;
-  margin: 0 10%
+  padding: 16px calc(16px + 10%);
+  overflow-y: auto;
 }
 
 h1.slackable-title {

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -42,7 +42,8 @@ $title-font-size: 1.125rem;
   background-color: $purple;
   color: #fff;
   font-size: $default-font-size;
-
+  overflow-y: auto;
+  
   .sidebar-menu {
     padding: 16px;
 

--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from '../App';
-import Enzyme from 'enzyme';
 import { shallow } from 'enzyme';
 import PageContainer from '../containers/PageContainer';
 


### PR DESCRIPTION

- makes the overall "App" component not scrollable and with a height exactly the size of the viewport.

- makes the "sidebar" and "dashboard" components vertically scrollable by giving them `overflow-y: auto`. 

- removes a random unused import. hehe

- wasn't really sure if unit tests are needed here as it's only css changes


![Screen Shot 2020-10-25 at 5 28 02 PM](https://user-images.githubusercontent.com/5354163/97119263-6e5f6700-16e5-11eb-84ed-3d6836ba469c.png)



happy hacktober! 🥳  🎃