### PR TITLE
Fix #82 Storybook is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build": "node scripts/build.js",
     "test": "jest",
     "test-watch": "jest --watchAll",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook"
   },
   "eslintConfig": {

--- a/src/stories/Dashboard.stories.js
+++ b/src/stories/Dashboard.stories.js
@@ -1,6 +1,15 @@
-import React from "react";
+import React, {useState} from "react";
+import presetThemes from '../data/themes';
 import Dashboard from "../components/DashBoard";
 
 export default { title: "Dashboard" };
 
-export const Default = () => <Dashboard />;
+export const Default = () => {
+  const [theme, setTheme] = useState(presetThemes[0].themeColor);
+
+  const updateTheme = (t) => {
+    setTheme([...t]);
+  };
+
+  return <Dashboard setTheme={updateTheme} theme={theme}/>
+};

--- a/src/stories/SideBar.stories.js
+++ b/src/stories/SideBar.stories.js
@@ -1,6 +1,11 @@
-import React from "react";
+import React, {useState} from "react";
 import SideBar from "../components/SideBar";
+import presetThemes from "../data/themes";
 
 export default { title: "Sidebar" };
 
-export const Default = () => <SideBar />;
+export const Default = () => {
+  const [theme] = useState(presetThemes[0].themeColor);
+
+  return <SideBar theme={theme} />
+};


### PR DESCRIPTION
Storybook wouldn't work because the presetThemes weren't being passed into Dashboard and Sidebar which those files expect. Then once i made that change the images for sidebar themes wouldn't load but i found the solution on the storybook docs, you need to pass in the directory where your assets live so i edited the npm script for storybook to include `-s ./public`

I hope this helps, let me know if there is anything you feel i missed or should have done. I'm not sure if any of the things listed below in your PR template are necessary for this PR but please let me know if there is anything else i can and should do.

Thank you for your contribution to the SlackableThemes repo! :raised_hands:

Add a descripting below of what this pull request is addressing and 
let us know if you need additional guidance or have questions about something.

Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved tech stack
- [ ] You have added unit tests
