### PR TITLE
shrinks sidebar on phones

### DIFF
--- a/src/styles/page-container.scss
+++ b/src/styles/page-container.scss
@@ -1,5 +1,7 @@
+@import 'sizing';
+
 .page-container {
   display: grid;
-  grid-template-columns: minmax(250px, max-content) auto;
+  grid-template-columns: minmax($sidebar-width, max-content) auto;
   height: 100vh;
 }

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+@import 'sizing';
 
 $default-font-size: 0.9375rem;
 $user-font-size: 0.875rem;
@@ -43,6 +44,7 @@ $title-font-size: 1.125rem;
   color: #fff;
   font-size: $default-font-size;
   overflow-y: auto;
+  width: $sidebar-width;
   
   .sidebar-menu {
     padding: 16px;

--- a/src/styles/sizing.scss
+++ b/src/styles/sizing.scss
@@ -1,0 +1,1 @@
+$sidebar-width: calc(135px + 9vw);


### PR DESCRIPTION

This is definitely not perfect, but maybe it's a start towards completing https://github.com/yisselda/SlackableThemes/issues/56, "make it look good on smaller screen sizes".

Basically, the sidebar width has a min width of 135px, but also scales with the viewport width. The tricky part is that both the sidebar component and the grid layout depend on this value so I put it in a sass variable in a new "sizing.scss" file.

Not sure what there is not little padding when the text in the sidebar wraps into the next line, but possibly that's something we could look at and other things like shrinking the font size a bit?

Is this how it's supposed to look? When things get as small as 320px it gets pretty tough to have a real sidebar and leave room for hardly anything next to it. 😅

Some screenshots at various widths:

desktop (1680px width):

![Screen Shot 2020-10-26 at 10 00 41 PM](https://user-images.githubusercontent.com/5354163/97247512-36841c80-17d6-11eb-93da-7de7674d0ffe.png)


tablet:
![Screen Shot 2020-10-26 at 10 01 33 PM](https://user-images.githubusercontent.com/5354163/97247519-3be16700-17d6-11eb-86e5-569afddf2f2a.png)






phone:


![Screen Shot 2020-10-26 at 10 01 50 PM](https://user-images.githubusercontent.com/5354163/97247527-400d8480-17d6-11eb-8303-874679c3ffef.png)

![Screen Shot 2020-10-26 at 10 01 10 PM](https://user-images.githubusercontent.com/5354163/97247552-4b60b000-17d6-11eb-9c17-0ff966bff64b.png)

