### PR TITLE
limit file uploader to accept only image file types

### DIFF
--- a/src/components/ImageUpload.js
+++ b/src/components/ImageUpload.js
@@ -30,7 +30,7 @@ const ImageUpload = ({ updateThemeColors, loadingColor }) => {
   return (
     <div className="image-upload-container">
       <div className="image-upload">
-        <Dropzone onDrop={onDrop} className="dropzone">
+        <Dropzone onDrop={onDrop} accept='image/*' className="dropzone">
           {({getRootProps, getInputProps}) => (
             <div {...getRootProps()} className="image-input" >
               <input {...getInputProps()} />

--- a/src/styles/image-upload.scss
+++ b/src/styles/image-upload.scss
@@ -9,6 +9,7 @@
   padding: 20px;
   margin: 20px auto;
   text-align: center;
+  cursor: pointer;
 }
 
 .image-input {


### PR DESCRIPTION
Issue: #75 

### Changes
- Limited the file types accepted by the file uploader by passing "image/*" as the "accept" prop. [react-dropzone docs](https://react-dropzone.js.org/#!/Accepting%20specific%20file%20types)
- cursor: pointer on the image uploader div so clicking to upload is more intuitive

Before submitting this PR, please make sure:

✅ Your code builds clean without any errors or warnings
✅ You are using approved tech stack
✅ You have added unit tests
